### PR TITLE
Added API for command-like options

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -119,7 +119,7 @@ exports.Cmd = Cmd = (function() {
   Cmd.prototype.helpful = function() {
     this._helpful = true;
     return this.opt().name('help').title('Help').short('h').long('help').flag().act(function() {
-      return this.usage();
+      return this.resolve(this.usage());
     }).end();
   };
   Cmd.prototype._exit = function(msg, code) {
@@ -270,17 +270,31 @@ exports.Cmd = Cmd = (function() {
     this._do(argv, function(res) {
       return this._exit(res.toString(), 0);
     }, function(res) {
-      return this._exit(res.toString(), 1);
+      return this._exit(res.reason.toString(), res.code);
     });
     return this;
   };
   /**
-  Return reject of actions results promise.
+  Return reject of actions results promise with error code.
   Use in .act() for return with error.
   @returns {Q.promise} rejected promise
   */
-  Cmd.prototype.reject = function(reason) {
-    return Q.reject(reason);
+  Cmd.prototype.reject = function(reason, code) {
+    if (code == null) {
+      code = 1;
+    }
+    return Q.reject({
+      reason: reason,
+      code: code
+    });
+  };
+  /**
+  Return resolved results promise (rejected in fact, but without error code).
+  Use in .act() to stop chain of actions and return without error.
+  @returns {Q.promise} rejected promise
+  */
+  Cmd.prototype.resolve = function(value) {
+    return this.reject(value, 0);
   };
   /**
   Finish chain for current subcommand and return parent command instance.

--- a/src/cmd.coffee
+++ b/src/cmd.coffee
@@ -115,7 +115,7 @@ exports.Cmd = class Cmd
             .short('h').long('help')
             .flag()
             .act ->
-                return @usage()
+                return @resolve @usage()
             .end()
 
 
@@ -256,16 +256,23 @@ exports.Cmd = class Cmd
         @_do(
             argv
             (res) -> @_exit res.toString(), 0
-            (res) -> @_exit res.toString(), 1
+            (res) -> @_exit res.reason.toString(), res.code
         )
         @
 
     ###*
-    Return reject of actions results promise.
+    Return reject of actions results promise with error code.
     Use in .act() for return with error.
     @returns {Q.promise} rejected promise
     ###
-    reject: (reason) -> Q.reject(reason)
+    reject: (reason, code = 1) -> Q.reject({ reason: reason, code: code })
+
+    ###*
+    Return resolved results promise (rejected in fact, but without error code).
+    Use in .act() to stop chain of actions and return without error.
+    @returns {Q.promise} rejected promise
+    ###
+    resolve: (value) -> @reject(value, 0)
 
     ###*
     Finish chain for current subcommand and return parent command instance.

--- a/tests/v.js
+++ b/tests/v.js
@@ -7,8 +7,11 @@ require('../lib/coa').Cmd()
         .short('v').long('version')
         .flag()
         .act(function(opts, args) {
-            return JSON.parse(require('fs').readFileSync(__dirname + '/../package.json'))
-                .version
+            return this.resolve(JSON.parse(require('fs').readFileSync(__dirname + '/../package.json'))
+                .version)
         })
         .end()
+    .act(function() {
+        console.log('... doing hard work ...')
+    })
     .run(['-v']);


### PR DESCRIPTION
Added API for command-like options: use return this.resolve(...) to stop the chain of actions. See tests/v.js. Fixes veged/coa#5
