### PR TITLE
Expose coa.Opt and coa.Arg

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,10 @@
 
 exports.Cmd = require('./cmd').Cmd;
 
+exports.Opt = require('./cmd').Opt;
+
+exports.Arg = require('./cmd').Arg;
+
 exports.shell = require('./shell');
 
 exports.require = require;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,3 +1,5 @@
 exports.Cmd = require('./cmd').Cmd
+exports.Opt = require('./cmd').Opt
+exports.Arg = require('./cmd').Arg
 exports.shell = require('./shell')
 exports.require = require;


### PR DESCRIPTION
It would be helpful to expose the Opt and Arg objects in the coa npm module. I need this to be able to add additional functions to ALL option and argument instances through Opt.prototype and Arg.prototype.
