### PR TITLE
Use console.error instead of deprecated util.error

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -240,7 +240,7 @@ exports.Cmd = Cmd = (function() {
   Cmd.prototype._exit = function(msg, code) {
     return process.once('exit', function() {
       if (msg) {
-        UTIL.error(msg);
+        console.error(msg);
       }
       return process.exit(code || 0);
     });

--- a/src/cmd.coffee
+++ b/src/cmd.coffee
@@ -178,7 +178,7 @@ exports.Cmd = class Cmd
 
     _exit: (msg, code) ->
         process.once 'exit', ->
-            if msg then UTIL.error msg
+            if msg then console.error msg
             process.exit code or 0
 
     ###*


### PR DESCRIPTION
util.log() and util.error() methods are deprecated and node v0.11 and higher shows messages like
```
util.error: Use console.error instead
````