### PR TITLE
update license because npm@v2.10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,6 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "optionalDependencies": {}
 }


### PR DESCRIPTION
license objects and a "licenses" property containing an array of license objects are now deprecated from npm@v2.10+

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/