### PR TITLE
Whitelist included files in `package.json`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-src/
-test/
-tests/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   "contributors": [
     "Sergey Belov <peimei@ya.ru> (http://github.com/arikon)"
   ],
+  "files": [
+    "lib/",
+    "index.js",
+    "README.ru.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/veged/coa.git"


### PR DESCRIPTION
This replaces the `.npmignore` file (which wasn't working for me) with a `files` entry in the `package.json` that allows only the needed files and directories 
for production use plus the Russian readme (which I believe wouldn't be included by default).