### PR TITLE
fix(cmd): String returned from act function printed to the stderr instead of stdout

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -192,7 +192,7 @@ class Cmd extends CoaObject {
 
     _exit(msg, code) {
         return process.once('exit', function() {
-            msg && console.error(msg);
+            msg && console[code === 0 ? 'log' : 'error'](msg);
             return process.exit(code || 0);
         });
     }


### PR DESCRIPTION
Closes #63 