### PR TITLE
Keep exit code from outer scope

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -191,9 +191,9 @@ class Cmd extends CoaObject {
     }
 
     _exit(msg, code) {
-        return process.once('exit', function() {
+        return process.once('exit', function(exitCode) {
             msg && console[code === 0 ? 'log' : 'error'](msg);
-            process.exit(code || 0);
+            process.exit(code || exitCode || 0);
         });
     }
 


### PR DESCRIPTION
Not sure is it a bug, but coa doesn't keep an exit code if `process.exit` was called somewhere outside.

```(js)
process.once('uncaughtException', () => {
  process.exit(1);
});

setTimeout(() => {
  throw Error('0_o');
}, 500);

require('coa').Cmd()
  .name('Ololo').title('Ololo')
  .act(() => {
    setTimeout(() => console.log('OK'), 1000);
  })
  .run(process.argv.slice(2));
```

**Expected Result**:
Exit code 1

**Actual Result**:
Exit code 0